### PR TITLE
Reduce type's documentation

### DIFF
--- a/h2d/Anim.hx
+++ b/h2d/Anim.hx
@@ -1,7 +1,7 @@
 package h2d;
 
 /**
-	`h2d.Anim` is used to display an animated sequence of bitmap tiles on the screen.
+	Display an animated sequence of bitmap tiles on the screen.
 **/
 class Anim extends Drawable {
 

--- a/h2d/Bitmap.hx
+++ b/h2d/Bitmap.hx
@@ -1,7 +1,7 @@
 package h2d;
 
 /**
-	`h2d.Bitmap` is used to display a single bitmap Tile on the screen.
+	Display a single bitmap Tile on the screen.
 **/
 class Bitmap extends Drawable {
 

--- a/h2d/BlendMode.hx
+++ b/h2d/BlendMode.hx
@@ -1,7 +1,7 @@
 package h2d;
 
 /**
-	BlendMode dictates the blending rule when rendering Tile/Material.
+	Dictates the blending rule when rendering Tile/Material.
 **/
 enum BlendMode {
 	/**

--- a/h2d/CdbLevel.hx
+++ b/h2d/CdbLevel.hx
@@ -243,7 +243,7 @@ class LevelLayer {
 }
 
 /**
-	CdbLevel will decode and display a level created with the CastleDB level editor.
+	Decode and display a level created with the CastleDB level editor.
 	See http://castledb.org for more details.
 **/
 class CdbLevel extends Layers {

--- a/h2d/CheckBox.hx
+++ b/h2d/CheckBox.hx
@@ -1,7 +1,7 @@
 package h2d;
 
 /**
-	`h2d.CheckBox` is a simple UI toggle component.
+	Simple UI toggle component.
 **/
 class CheckBox extends h2d.Flow {
 	/**

--- a/h2d/Console.hx
+++ b/h2d/Console.hx
@@ -24,7 +24,7 @@ typedef ConsoleArgDesc = {
 }
 
 /**
-	`h2d.Console` provides simple debug console integration.
+	Simple debug console integration.
 
 	By default comes with 2 commands: `help` and `cls`, which print help message
 	describing all command and clear the screen respectively.

--- a/h2d/Drawable.hx
+++ b/h2d/Drawable.hx
@@ -1,7 +1,7 @@
 package h2d;
 
 /**
-	h2d.Drawable is the base class for all 2D objects that will draw something on screen.
+	Base class for all 2D objects that will draw something on screen.
 	Unlike Object base class, all properties of Drawable only apply to the current object and are not inherited by its children.
 **/
 class Drawable extends Object {

--- a/h2d/Dropdown.hx
+++ b/h2d/Dropdown.hx
@@ -31,7 +31,7 @@ private class Fake extends Object {
 }
 
 /**
-	`h2d.Dropdown` is a simple UI component that creates an interactive drop-down list.
+	Simple UI component that creates an interactive drop-down list.
 	Dropdown will add an `h2d.Flow` to `Scene` when opening in order to be visible above other objects. See `dropdownLayer`.  
 	Note that when `dropdownList` opens and closes, item objects will receive the `onHierarchyChanged` callback.
 **/

--- a/h2d/Flow.hx
+++ b/h2d/Flow.hx
@@ -84,7 +84,7 @@ class FlowProperties {
 }
 
 /**
-	`h2d.Flow` provides an automatic layout system.
+	Automatic layout system.
 **/
 class Flow extends Object {
 

--- a/h2d/Graphics.hx
+++ b/h2d/Graphics.hx
@@ -133,7 +133,7 @@ private class GraphicsContent extends h3d.prim.Primitive {
 }
 
 /**
-	`h2d.Graphics` provide simple interface to draw arbitrary geometry.
+	Simple interface to draw arbitrary geometry.
 
 	Usage notes:
 	* When rendering Tiles, there is a limitation of only one unique Texture per Graphics instance.

--- a/h2d/HtmlText.hx
+++ b/h2d/HtmlText.hx
@@ -18,7 +18,7 @@ enum LineHeightMode {
 }
 
 /**
-	`h2d.HtmlText` is a simple HTML text renderer.
+	Simple HTML text renderer.
 	See Text section of the manual for more details and list of supported HTML tags.
 **/
 class HtmlText extends Text {

--- a/h2d/Layers.hx
+++ b/h2d/Layers.hx
@@ -1,7 +1,7 @@
 package h2d;
 
 /**
- * `h2d.Layers` allows to hierarchically organize objects on different layers and supports Y-sorting.
+ * Hierarchically organize objects on different layers and supports Y-sorting.
  */
 class Layers extends Object {
 

--- a/h2d/Mask.hx
+++ b/h2d/Mask.hx
@@ -1,7 +1,7 @@
 package h2d;
 
 /**
-	`h2d.Mask` allows to restrict rendering area within `[width, height]` rectangle.
+	Restrict rendering area within `[width, height]` rectangle.
 	For more advanced masking, see `h2d.filter.AbstractMask`.
 **/
 class Mask extends Object {

--- a/h2d/RenderContext.hx
+++ b/h2d/RenderContext.hx
@@ -3,7 +3,7 @@ package h2d;
 private typedef RenderZoneStack = { hasRZ:Bool, x:Float, y:Float, w:Float, h:Float };
 
 /**
-	`h2d.RenderContext` provides 2D scene rendering capabilities.
+	2D scene rendering capabilities.
 **/
 class RenderContext extends h3d.impl.RenderContext {
 

--- a/h2d/ScaleGrid.hx
+++ b/h2d/ScaleGrid.hx
@@ -1,7 +1,7 @@
 package h2d;
 
 /**
-	`h2d.ScaleGrid` provides simple 9-slice bitmap renderer.
+	Simple 9-slice bitmap renderer.
 **/
 class ScaleGrid extends h2d.TileGroup {
 

--- a/h2d/Scene.hx
+++ b/h2d/Scene.hx
@@ -68,7 +68,7 @@ enum ScaleMode {
 }
 
 /**
-	h2d.Scene is the root class for a 2D scene. All root objects are added to it before being drawn on screen.
+	Root class for a 2D scene. All root objects are added to it before being drawn on screen.
 **/
 class Scene extends Layers implements h3d.IDrawable implements hxd.SceneEvents.InteractiveScene {
 

--- a/h2d/Slider.hx
+++ b/h2d/Slider.hx
@@ -1,7 +1,7 @@
 package h2d;
 
 /**
-	`h2d.Silder` is a simple interactive horizontal numerical slider.
+	Simple interactive horizontal numerical slider.
 **/
 class Slider extends h2d.Interactive {
 	/**

--- a/h2d/SpriteBatch.hx
+++ b/h2d/SpriteBatch.hx
@@ -129,7 +129,7 @@ class BatchElement {
 }
 
 /**
-	`h2d.SpriteBatch.BasicElement` is a BatchElement that provides simple simulation of velocity, friction and gravity.
+	BatchElement that provides simple simulation of velocity, friction and gravity.
 	Parent BatchElement should have `hasUpdate` set to true in order for element to work properly.
 **/
 class BasicElement extends BatchElement {

--- a/h2d/Text.hx
+++ b/h2d/Text.hx
@@ -61,7 +61,7 @@ enum Align {
 }
 
 /**
-	`h2d.Text` is basic text renderer with multiline support.
+	Basic text renderer with multiline support.
 	See Text section of the manual for more details.
 **/
 class Text extends Drawable {

--- a/h2d/TextInput.hx
+++ b/h2d/TextInput.hx
@@ -4,7 +4,7 @@ import hxd.Key in K;
 private typedef TextHistoryElement = { t : String, c : Int, sel : { start : Int, length : Int } };
 
 /**
-	`h2d.TextInput` is a skinnable text input handler.
+	Skinnable text input handler.
 **/
 class TextInput extends Text {
 

--- a/h2d/TileGroup.hx
+++ b/h2d/TileGroup.hx
@@ -495,7 +495,7 @@ class TileLayerContent extends h3d.prim.Primitive {
 }
 
 /**
-	`h2d.TileGroup` is a static Tile batch renderer.
+	Static Tile batch renderer.
 	It's limited to one unique texture, but allows to render all Tiles in single drawcall.
 
 	TileGroup follows upload-once policy and does not allow modification of the already added geometry.

--- a/h2d/Video.hx
+++ b/h2d/Video.hx
@@ -24,7 +24,7 @@ private abstract VideoImpl(hl.Abstract<"hl_video">) {
 #end
 
 /**
-	`h2d.Video` allows playback of video files, however each target platform have it's own limitations.
+	Playback of video files, however each target platform have it's own limitations.
 	For hashlink it depends on `video` library (at the time of HL 1.11 it's not bundled and have to be [compiled manually](https://github.com/HaxeFoundation/hashlink/tree/master/libs/video) with FFMPEG)
 	For JS it will use HTML Video element and will be restricted by content-security policy and browser decoder capabilities.
 **/

--- a/h2d/col/Bounds.hx
+++ b/h2d/col/Bounds.hx
@@ -1,7 +1,7 @@
 package h2d.col;
 import hxd.Math;
 /**
-	`h2d.col.Bounds` represent a 2D bounding box often used for determining Object bounding area.
+	2D bounding box often used for determining Object bounding area.
 
 	Bounds holds min/max coordinates of bounding box instead of it's position and size.
 **/

--- a/h2d/col/Circle.hx
+++ b/h2d/col/Circle.hx
@@ -2,7 +2,7 @@ package h2d.col;
 import hxd.Math;
 
 /**
-	`h2d.col.Circle` provides an implementation for `Collider` interfaces with circular hitbox.
+	Implementation for `Collider` interfaces with circular hitbox.
 **/
 class Circle implements Collider {
 

--- a/h2d/col/IBounds.hx
+++ b/h2d/col/IBounds.hx
@@ -2,7 +2,7 @@ package h2d.col;
 import hxd.Math;
 
 /**
-	`h2d.col.IBounds` is an `Int`-based version of `h2d.col.Bounds`.
+	`Int`-based version of `h2d.col.Bounds`.
 **/
 class IBounds {
 

--- a/h2d/col/IPoint.hx
+++ b/h2d/col/IPoint.hx
@@ -2,7 +2,7 @@ package h2d.col;
 import hxd.Math;
 
 /**
-	`h2d.col.IPoint` is an `Int`-based version of `h2d.col.Point`.
+	`Int`-based version of `h2d.col.Point`.
 **/
 class IPoint {
 

--- a/h2d/col/Line.hx
+++ b/h2d/col/Line.hx
@@ -1,7 +1,7 @@
 package h2d.col;
 
 /**
-	`h2d.col.Line` represents a line segment between two Points. 
+	Line segment between two Points. 
 **/
 class Line {
 

--- a/h2d/col/PixelsCollider.hx
+++ b/h2d/col/PixelsCollider.hx
@@ -1,7 +1,7 @@
 package h2d.col;
 
 /**
-	A Pixels collider. Checks for pixel color value under point to be above the cutoff value.
+	Checks for pixel color value under point to be above the cutoff value.
 	Note that it checks as `channel > cutoff`, not `channel >= cutoff`, hence value of 255 will always be considered below cutoff.
 **/
 class PixelsCollider implements Collider {

--- a/h2d/col/Point.hx
+++ b/h2d/col/Point.hx
@@ -2,7 +2,7 @@ package h2d.col;
 import hxd.Math;
 
 /**
-	`h2d.col.Point` is simple 2D position container.
+	Simple 2D position container.
 **/
 class Point {
 

--- a/h2d/col/PolygonCollider.hx
+++ b/h2d/col/PolygonCollider.hx
@@ -1,7 +1,7 @@
 package h2d.col;
 
 /**
-	`PolygonCollider` is a wrapper around `Polygons`, allowing its usage as a collision shape.
+	Wrapper around `Polygons`, allowing its usage as a collision shape.
 **/
 class PolygonCollider implements Collider {
 	/**

--- a/h2d/col/Ray.hx
+++ b/h2d/col/Ray.hx
@@ -2,7 +2,7 @@ package h2d.col;
 import hxd.Math;
 
 /**
-	`h2d.col.Ray` represents a raycast from given position in a specified direction.
+	Raycast from given position in a specified direction.
 **/
 class Ray {
 	/** X position of the ray start. **/

--- a/h2d/col/Segment.hx
+++ b/h2d/col/Segment.hx
@@ -2,7 +2,7 @@ package h2d.col;
 import hxd.Math;
 
 /**
-	`h2d.col.Segment` is a 2D line segment.
+	2D line segment.
 **/
 class Segment {
 

--- a/h2d/col/Voronoi.hx
+++ b/h2d/col/Voronoi.hx
@@ -567,7 +567,7 @@ private class CircleEvent extends RBNode<CircleEvent> {
 }
 
 /**
-	`h2d.col.Voronoi` allows to Steven Fortune's algorithm to compute Voronoi diagram from given set of Points and bounding box.
+	Steven Fortune's algorithm to compute Voronoi diagram from given set of Points and bounding box.
 	The implementation is a port from JS library: https://github.com/gorhill/Javascript-Voronoi
 **/
 class Voronoi {

--- a/h2d/filter/AbstractMask.hx
+++ b/h2d/filter/AbstractMask.hx
@@ -21,7 +21,7 @@ class Hide extends Filter {
 }
 
 /**
-	AbstractMask is a base class for filters that utilize separate Objects as a masking object.
+	Base class for filters that utilize separate Objects as a masking object.
 	Not intended to be used directly.
 **/
 class AbstractMask extends Filter {

--- a/h2d/filter/Displacement.hx
+++ b/h2d/filter/Displacement.hx
@@ -2,7 +2,7 @@ package h2d.filter;
 import hxd.Math;
 
 /**
-	Displacement filter allows to apply a normal map to the filtered Object in order to displace pixels.
+	Apply a normal map to the filtered Object in order to displace pixels.
 
 	Uses red and green channels to displaces horizontal and vertical axes acoordingly.
 **/

--- a/h2d/filter/Mask.hx
+++ b/h2d/filter/Mask.hx
@@ -23,7 +23,7 @@ private class MaskShader extends h3d.shader.ScreenShader {
 }
 
 /**
-	Allows to perform arbitrary shape masking of the filtered Object.
+	Perform arbitrary shape masking of the filtered Object.
 **/
 class Mask extends AbstractMask {
 

--- a/h2d/filter/Outline.hx
+++ b/h2d/filter/Outline.hx
@@ -1,7 +1,7 @@
 package h2d.filter;
 
 /**
-	Provies a solid color outline to the filtered object by utilizing `h3d.pass.Outline` render pass.
+	Solid color outline to the filtered object by utilizing `h3d.pass.Outline` render pass.
 **/
 class Outline extends Filter {
 	/**

--- a/h2d/filter/Shader.hx
+++ b/h2d/filter/Shader.hx
@@ -1,7 +1,7 @@
 package h2d.filter;
 
 /**
-	Shader filter allows to easily implement custom filters without need to fiddle with render passes.
+	Easily implement custom filters without need to fiddle with render passes.
 
 	Compatible shaders should extend from `h3d.shader.ScreenShader` and contain an input texture uniform, as well as assign `pixelColor` in fragment shader.
 


### PR DESCRIPTION
Removes the following from type's documentation (in h2d only) where it is ok to do so:
- "T is used to..."
- "T provides..."
- "T implements..."
- "T will..."
- "T is a..."
- "T represents..."
- etc...